### PR TITLE
erc: error mangling tools and helpers

### DIFF
--- a/erc/helpers.go
+++ b/erc/helpers.go
@@ -178,10 +178,9 @@ func StreamInto(ctx context.Context, ec *Collector, errCh <-chan error) {
 		case <-ctx.Done():
 			return
 		case err, ok := <-errCh:
-			if !ok {
+			if !ok || ctx.Err() != nil {
 				return
 			}
-
 			ec.Add(err)
 		}
 	}

--- a/erc/helpers.go
+++ b/erc/helpers.go
@@ -4,6 +4,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sync"
+
+	"github.com/tychoish/fun/internal"
 )
 
 // ContextExpired checks an error to see if it, or any of it's parent
@@ -116,4 +119,83 @@ func Unwind(err error) []error {
 	}
 
 	return out
+}
+
+// Merge produces a single error from two input errors. The output
+// error behaves correctly for errors.Is and errors.As and Unwrap()
+// calls, for both errors, checked in order.
+//
+// If both errors are of the same root type and you investigate the
+// output error with errors.As, the first error's value will be used.
+func Merge(err1, err2 error) error { return &internal.DoubleWrappedError{Current: err1, Wrapped: err2} }
+
+// Collapse takes a slice of errors and converts it into an *erc.Stack
+// typed error.
+func Collapse(errs ...error) error {
+	if len(errs) == 0 {
+		return nil
+	}
+
+	ec := &Collector{}
+
+	CollapseFrom(ec, errs)
+
+	return ec.Resolve()
+}
+
+// CollapseInto is a helper that has the same semantics and calling
+// pattern as Collapse, but collapses those errors into the provided
+// Collector.
+func CollapseInto(ec *Collector, errs ...error) { CollapseFrom(ec, errs) }
+
+// CollapseFrom is a helper that adds a slice of errors to the
+// provided Collector.
+func CollapseFrom(ec *Collector, errs []error) {
+	for idx := range errs {
+		ec.Add(errs[idx])
+	}
+}
+
+// Stream collects all errors from an error channel, and returns the
+// aggregated error. Stream blocks until the context expires (but
+// does not add a context cancellation error) or the error channel is
+// closed.
+func Stream(ctx context.Context, errCh <-chan error) error {
+	ec := &Collector{}
+
+	StreamInto(ctx, ec, errCh)
+
+	return ec.Resolve()
+}
+
+// StreamInto collects all errors from an error channel and adds them
+// to the provided collector. StreamInto blocks until the context
+// expires (but does not add a context cancellation error) or the
+// error channel is closed.
+func StreamInto(ctx context.Context, ec *Collector, errCh <-chan error) {
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case err, ok := <-errCh:
+			if !ok {
+				return
+			}
+
+			ec.Add(err)
+		}
+	}
+}
+
+// StreamProcess is a non-blocking helper that starts a background
+// goroutine to process the contents of an error channel, and uses the
+// provided wait group to account for the lifecycle of the goroutine.
+func StreamProcess(ctx context.Context, wg *sync.WaitGroup, ec *Collector, errCh <-chan error) {
+	wg.Add(1)
+
+	go func() {
+		defer wg.Done()
+		defer Recover(ec)
+		StreamInto(ctx, ec, errCh)
+	}()
 }

--- a/erc/helpers_test.go
+++ b/erc/helpers_test.go
@@ -1,0 +1,303 @@
+package erc
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/tychoish/fun"
+)
+
+type errorTest struct {
+	val int
+}
+
+func (e *errorTest) Error() string { return fmt.Sprint("error: ", e.val) }
+
+func TestCollections(t *testing.T) {
+	t.Run("Merge", func(t *testing.T) {
+		e1 := &errorTest{val: 100}
+		e2 := &errorTest{val: 200}
+
+		err := Merge(e1, e2)
+
+		if err == nil {
+			t.Fatal("should be an error")
+		}
+		if !errors.Is(err, e1) {
+			t.Error("shold be er1", err, e1)
+		}
+
+		if !errors.Is(err, e2) {
+			t.Error("shold be er2", err, e2)
+		}
+		cp := &errorTest{}
+		if !errors.As(err, &cp) {
+			t.Error("should err as", err, cp)
+		}
+		if cp.val != e1.val {
+			t.Error(cp.val)
+		}
+	})
+	t.Run("Collapse", func(t *testing.T) {
+		t.Run("From", func(t *testing.T) {
+			t.Run("Empty", func(t *testing.T) {
+				ec := &Collector{}
+				CollapseFrom(ec, nil)
+				if err := ec.Resolve(); err != nil {
+					t.Error("should be nil", err)
+				}
+				ec = &Collector{}
+				CollapseFrom(ec, []error{})
+				if err := ec.Resolve(); err != nil {
+					t.Error("should be nil", err)
+				}
+			})
+			t.Run("One", func(t *testing.T) {
+				ec := &Collector{}
+				e := errors.New("fourty-two")
+				CollapseFrom(ec, []error{e})
+				err := ec.Resolve()
+				if !errors.Is(err, e) {
+					t.Error(err, e)
+				}
+			})
+			t.Run("Many", func(t *testing.T) {
+				ec := &Collector{}
+				e0 := errors.New("fourty-two")
+				e1 := errors.New("fourty-three")
+				CollapseFrom(ec, []error{e0, e1})
+				err := ec.Resolve()
+				if !errors.Is(err, e1) {
+					t.Error(err, e1)
+				}
+				if !errors.Is(err, e0) {
+					t.Error(err, e0)
+				}
+				errs := Unwind(err)
+				if len(errs) != 2 {
+					t.Error(errs)
+				}
+			})
+		})
+		t.Run("Into", func(t *testing.T) {
+			t.Run("From", func(t *testing.T) {
+				t.Run("Empty", func(t *testing.T) {
+					ec := &Collector{}
+					CollapseInto(ec, nil)
+					if err := ec.Resolve(); err != nil {
+						t.Error("should be nil", err)
+					}
+					ec = &Collector{}
+					CollapseInto(ec)
+					if err := ec.Resolve(); err != nil {
+						t.Error("should be nil", err)
+					}
+				})
+				t.Run("One", func(t *testing.T) {
+					ec := &Collector{}
+					e := errors.New("fourty-two")
+					CollapseInto(ec, e)
+					err := ec.Resolve()
+					if !errors.Is(err, e) {
+						t.Error(err, e)
+					}
+				})
+				t.Run("Many", func(t *testing.T) {
+					ec := &Collector{}
+					e0 := errors.New("fourty-two")
+					e1 := errors.New("fourty-three")
+					CollapseInto(ec, e0, e1)
+					err := ec.Resolve()
+					if !errors.Is(err, e1) {
+						t.Error(err, e1)
+					}
+					if !errors.Is(err, e0) {
+						t.Error(err, e0)
+					}
+					errs := Unwind(err)
+					if len(errs) != 2 {
+						t.Error(errs)
+					}
+				})
+			})
+		})
+		t.Run("Base", func(t *testing.T) {
+			t.Run("Empty", func(t *testing.T) {
+				if err := Collapse(); err != nil {
+					t.Error("should be nil", err)
+				}
+			})
+			t.Run("One", func(t *testing.T) {
+				e := errors.New("fourty-two")
+				err := Collapse(e)
+				if !errors.Is(err, e) {
+					t.Error(err, e)
+				}
+			})
+			t.Run("Many", func(t *testing.T) {
+				e0 := errors.New("fourty-two")
+				e1 := errors.New("fourty-three")
+				err := Collapse(e0, e1)
+				if !errors.Is(err, e1) {
+					t.Error(err, e1)
+				}
+				if !errors.Is(err, e0) {
+					t.Error(err, e0)
+				}
+				errs := Unwind(err)
+				if len(errs) != 2 {
+					t.Error(errs)
+				}
+			})
+		})
+	})
+	t.Run("Stream", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		t.Run("Base", func(t *testing.T) {
+			t.Run("Empty", func(t *testing.T) {
+				ch := make(chan error)
+				close(ch)
+				err := Stream(ctx, ch)
+				if err != nil {
+					t.Error("nil expected", err)
+				}
+			})
+
+			t.Run("One", func(t *testing.T) {
+				ch := getPopulatedErrChan(1)
+				close(ch)
+				err := Stream(ctx, ch)
+				if err == nil {
+					t.Logf("%T", err)
+					t.Error("nil expected", err)
+				}
+				errs := Unwind(err)
+				if len(errs) != 1 {
+					t.Error(errs)
+				}
+			})
+			t.Run("Many", func(t *testing.T) {
+				ch := getPopulatedErrChan(10)
+				close(ch)
+				fun.Invariant(len(ch) == 10)
+				err := Stream(ctx, ch)
+				if err == nil {
+					t.Logf("%T", err)
+					t.Error("nil expected", err)
+				}
+				errs := Unwind(err)
+				if len(errs) != 10 {
+					t.Error(errs)
+				}
+			})
+		})
+		t.Run("Into", func(t *testing.T) {
+			t.Run("Many", func(t *testing.T) {
+				ch := getPopulatedErrChan(10)
+				close(ch)
+				fun.Invariant(len(ch) == 10)
+				ec := &Collector{}
+				StreamInto(ctx, ec, ch)
+				err := ec.Resolve()
+				if err == nil {
+					t.Logf("%T", err)
+					t.Error("nil expected", err)
+				}
+				errs := Unwind(err)
+				if len(errs) != 10 {
+					t.Error(errs)
+				}
+			})
+			t.Run("CanceledWithContent", func(t *testing.T) {
+				ctx, cancel := context.WithCancel(context.Background())
+				cancel()
+				ch := getPopulatedErrChan(10)
+				close(ch)
+				fun.Invariant(len(ch) == 10)
+				ec := &Collector{}
+				StreamInto(ctx, ec, ch)
+				err := ec.Resolve()
+				if err != nil {
+					t.Error(err)
+				}
+				errs := Unwind(err)
+				if len(errs) != 0 {
+					t.Error("no errors expected with empty context")
+				}
+			})
+			t.Run("Canceled", func(t *testing.T) {
+				// the real test here is that it
+				// doesn't deadlock
+				ctx, cancel := context.WithCancel(context.Background())
+				cancel()
+				ch := getPopulatedErrChan(0)
+				ec := &Collector{}
+				StreamInto(ctx, ec, ch)
+				err := ec.Resolve()
+				if err != nil {
+					t.Error(err)
+				}
+				errs := Unwind(err)
+				if len(errs) != 0 {
+					t.Error("no errors expected with empty context")
+				}
+			})
+		})
+		t.Run("Process", func(t *testing.T) {
+			t.Run("Many", func(t *testing.T) {
+				ctx, cancel := context.WithCancel(context.Background())
+				defer cancel()
+				ch := getPopulatedErrChan(10)
+				close(ch)
+				fun.Invariant(len(ch) == 10)
+				fun.Invariant(ctx.Err() == nil, ctx.Err())
+				wg := &sync.WaitGroup{}
+				ec := &Collector{}
+				StreamProcess(ctx, wg, ec, ch)
+				wg.Wait()
+				err := ec.Resolve()
+				if err == nil {
+					t.Logf("%T", err)
+					t.Error("nil expected", err)
+				}
+				errs := Unwind(err)
+				if len(errs) != 10 {
+					t.Error(len(errs), errs, err)
+				}
+			})
+			t.Run("Canceled", func(t *testing.T) {
+				ctx, cancel := context.WithCancel(ctx)
+				cancel()
+				ch := getPopulatedErrChan(10)
+				close(ch)
+				fun.Invariant(len(ch) == 10)
+				wg := &sync.WaitGroup{}
+				ec := &Collector{}
+				StreamProcess(ctx, wg, ec, ch)
+				wg.Wait()
+				err := ec.Resolve()
+				if err != nil {
+					t.Error(err)
+				}
+				errs := Unwind(err)
+				if len(errs) != 0 {
+					t.Error("no errors expected with empty context")
+				}
+			})
+
+		})
+	})
+}
+
+func getPopulatedErrChan(size int) chan error {
+	out := make(chan error, size)
+
+	for i := 0; i < size; i++ {
+		out <- fmt.Errorf("mock err %d", i)
+	}
+	return out
+}

--- a/internal/errors.go
+++ b/internal/errors.go
@@ -1,0 +1,18 @@
+package internal
+
+import (
+	"errors"
+	"fmt"
+)
+
+type DoubleWrappedError struct {
+	Current error
+	Wrapped error
+}
+
+var _ error = &DoubleWrappedError{}
+
+func (dwe *DoubleWrappedError) Error() string        { return fmt.Sprintf("%v: %v", dwe.Current, dwe.Wrapped) }
+func (dwe *DoubleWrappedError) Is(target error) bool { return errors.Is(dwe.Current, target) }
+func (dwe *DoubleWrappedError) As(target any) bool   { return errors.As(dwe.Current, target) }
+func (dwe *DoubleWrappedError) Unwrap() error        { return dwe.Wrapped }

--- a/internal/errors_test.go
+++ b/internal/errors_test.go
@@ -1,0 +1,42 @@
+package internal
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+)
+
+type errorTest struct {
+	val int
+}
+
+func (e *errorTest) Error() string { return fmt.Sprint("error: ", e.val) }
+
+func TestMerge(t *testing.T) {
+	e1 := &errorTest{val: 100}
+	e2 := &errorTest{val: 200}
+
+	err := &DoubleWrappedError{Current: e1, Wrapped: e2}
+
+	if !errors.Is(err, e1) {
+		t.Error("shold be er1", err, e1)
+	}
+
+	if !errors.Is(err, e2) {
+		t.Error("shold be er2", err, e2)
+	}
+	cp := &errorTest{}
+	if !errors.As(err, &cp) {
+		t.Error("should err as", err, cp)
+	}
+	if cp.val != e1.val {
+		t.Error(cp.val)
+	}
+	if !strings.Contains(err.Error(), "100") {
+		t.Error(err)
+	}
+	if !strings.Contains(err.Error(), "200") {
+		t.Error(err)
+	}
+}

--- a/internal/iterators.go
+++ b/internal/iterators.go
@@ -66,7 +66,9 @@ type MapIterImpl[T any] struct {
 }
 
 func (iter *MapIterImpl[T]) Close() error {
-	iter.Closer()
+	if iter.Closer != nil {
+		iter.Closer()
+	}
 	iter.WG.Wait()
-	return iter.ChannelIterImpl.Close()
+	return iter.Error
 }

--- a/internal/iterators_test.go
+++ b/internal/iterators_test.go
@@ -1,0 +1,176 @@
+package internal
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func makeClosedSlice[T any](in []T) <-chan T {
+	out := make(chan T, len(in))
+	for i := range in {
+		out <- in[i]
+	}
+	close(out)
+	return out
+}
+
+func TestIterators(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	t.Run("Slice", func(t *testing.T) {
+		t.Run("End2End", func(t *testing.T) {
+			iter := &SliceIterImpl[int]{Index: -1, Vals: []int{1, 2, 3, 4}}
+			seen := 0
+			for iter.Next(ctx) {
+				seen++
+				if iter.Value() > 4 || iter.Value() <= 0 {
+					t.Error(iter.Value())
+				}
+			}
+			if seen != 4 {
+				t.Error(seen)
+			}
+			if iter.Close() != nil {
+				t.Error(iter.Close())
+			}
+		})
+		t.Run("Canceled", func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+			cancel()
+			iter := &SliceIterImpl[int]{}
+			seen := 0
+			for iter.Next(ctx) {
+				seen++
+			}
+			if seen != 0 {
+				t.Error(seen)
+			}
+			if iter.Close() != nil {
+				t.Error(iter.Close())
+			}
+		})
+	})
+	t.Run("Channel", func(t *testing.T) {
+		t.Run("End2End", func(t *testing.T) {
+			var closerCalled bool
+			iter := &ChannelIterImpl[int]{
+				Pipe:   makeClosedSlice([]int{1, 2, 3, 4}),
+				Closer: func() { closerCalled = true },
+			}
+			seen := 0
+			for iter.Next(ctx) {
+				seen++
+				if iter.Value() > 4 || iter.Value() <= 0 {
+					t.Error(iter.Value())
+				}
+			}
+			if seen != 4 {
+				t.Error(seen)
+			}
+			if closerCalled {
+				t.Error("closer called early")
+			}
+			if iter.Close() != nil {
+				t.Error(iter.Close())
+			}
+			if !closerCalled {
+				t.Error("closer not called")
+			}
+		})
+		t.Run("Canceled", func(t *testing.T) {
+			t.Run("Before", func(t *testing.T) {
+				ctx, cancel := context.WithCancel(context.Background())
+				cancel()
+				iter := &ChannelIterImpl[int]{}
+				seen := 0
+				for iter.Next(ctx) {
+					seen++
+				}
+				if seen != 0 {
+					t.Error(seen)
+				}
+				if iter.Close() != nil {
+					t.Error(iter.Close())
+				}
+			})
+			t.Run("During", func(t *testing.T) {
+				iter := &ChannelIterImpl[int]{Pipe: make(chan int)}
+				seen := 0
+				sig := make(chan struct{})
+				go func() { defer close(sig); time.Sleep(5 * time.Millisecond); cancel() }()
+				for iter.Next(ctx) {
+					seen++
+				}
+				if seen != 0 {
+					t.Error(seen)
+				}
+			})
+		})
+	})
+	t.Run("Map", func(t *testing.T) {
+		t.Run("End2End", func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			var closerCalled bool
+			iter := &MapIterImpl[int]{
+				ChannelIterImpl: ChannelIterImpl[int]{
+					Pipe:   makeClosedSlice([]int{1, 2, 3, 4}),
+					Closer: func() { closerCalled = true },
+				},
+			}
+			seen := 0
+			for iter.Next(ctx) {
+				seen++
+				if iter.Value() > 4 || iter.Value() <= 0 {
+					t.Error(iter.Value())
+				}
+			}
+			if seen != 4 {
+				t.Error(seen)
+			}
+			if closerCalled {
+				t.Error("closer called early")
+			}
+			if iter.Close() != nil {
+				t.Error(iter.Close())
+			}
+			if !closerCalled {
+				t.Error("closer not called")
+			}
+		})
+		t.Run("Waiting", func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			iter := &MapIterImpl[int]{
+				ChannelIterImpl: ChannelIterImpl[int]{
+					Pipe: makeClosedSlice([]int{1, 2, 3, 4}),
+				},
+			}
+			seen := 0
+			for iter.Next(ctx) {
+				seen++
+			}
+			if seen != 4 {
+				t.Error("unexpected", seen)
+			}
+			start := time.Now()
+			iter.WG.Add(1)
+			go func() {
+				defer iter.WG.Done()
+				time.Sleep(10 * time.Millisecond)
+			}()
+			if err := iter.Close(); err != nil {
+				t.Error(err)
+			}
+			if time.Since(start) < 10*time.Millisecond {
+				t.Error(time.Since(start))
+			}
+		})
+
+	})
+
+}

--- a/panic.go
+++ b/panic.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+
+	"github.com/tychoish/fun/internal"
 )
 
 // ErrInvariantViolation is the root error of the error object that is
@@ -20,35 +22,23 @@ func Invariant(cond bool, args ...any) {
 		case 1:
 			switch ei := args[0].(type) {
 			case error:
-				panic(&doubleWrappedError{current: ei, wrapped: ErrInvariantViolation})
+				panic(&internal.DoubleWrappedError{Current: ei, Wrapped: ErrInvariantViolation})
 			case string:
-				panic(&doubleWrappedError{current: errors.New(ei), wrapped: ErrInvariantViolation})
+				panic(&internal.DoubleWrappedError{Current: errors.New(ei), Wrapped: ErrInvariantViolation})
 			default:
 				panic(fmt.Errorf("[%v]: %w", args[0], ErrInvariantViolation))
 			}
 		default:
 			if err, ok := args[0].(error); ok {
-				panic(&doubleWrappedError{
-					current: fmt.Errorf("[%s]", args[1:]),
-					wrapped: &doubleWrappedError{current: err, wrapped: ErrInvariantViolation},
+				panic(&internal.DoubleWrappedError{
+					Current: fmt.Errorf("[%s]", args[1:]),
+					Wrapped: &internal.DoubleWrappedError{Current: err, Wrapped: ErrInvariantViolation},
 				})
 			}
 			panic(fmt.Errorf("[%s]: %w", fmt.Sprintln(args...), ErrInvariantViolation))
 		}
 	}
 }
-
-type doubleWrappedError struct {
-	current error
-	wrapped error
-}
-
-var _ error = &doubleWrappedError{}
-
-func (dwe *doubleWrappedError) Error() string        { return fmt.Sprintf("%v: %v", dwe.current, dwe.wrapped) }
-func (dwe *doubleWrappedError) Is(target error) bool { return errors.Is(dwe.current, target) }
-func (dwe *doubleWrappedError) As(target any) bool   { return errors.As(dwe.current, target) }
-func (dwe *doubleWrappedError) Unwrap() error        { return dwe.wrapped }
 
 // InvariantMust raises an invariant error if the error is not
 // nil. The content of the panic is both--via wrapping--an
@@ -58,9 +48,9 @@ func InvariantMust(err error, args ...any) {
 		return
 	}
 
-	panic(&doubleWrappedError{
-		current: fmt.Errorf("%s: %w", fmt.Sprint(args...), err),
-		wrapped: ErrInvariantViolation,
+	panic(&internal.DoubleWrappedError{
+		Current: fmt.Errorf("%s: %w", fmt.Sprint(args...), err),
+		Wrapped: ErrInvariantViolation,
 	})
 }
 

--- a/panic_test.go
+++ b/panic_test.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"strings"
 	"testing"
+
+	"github.com/tychoish/fun/internal"
 )
 
 func TestPanics(t *testing.T) {
@@ -174,15 +176,15 @@ func TestPanics(t *testing.T) {
 	t.Run("MergedError", func(t *testing.T) {
 		t.Run("Empty", func(t *testing.T) {
 			e := &errorTest{}
-			err := &doubleWrappedError{}
+			err := &internal.DoubleWrappedError{}
 			if errors.As(err, &e) {
 				t.Fatal("should not validate")
 			}
 		})
 		t.Run("Current", func(t *testing.T) {
 			e := &errorTest{}
-			err := &doubleWrappedError{
-				current: &errorTest{val: 100},
+			err := &internal.DoubleWrappedError{
+				Current: &errorTest{val: 100},
 			}
 			if !errors.As(err, &e) {
 				t.Fatal("should not validate")
@@ -193,8 +195,8 @@ func TestPanics(t *testing.T) {
 		})
 		t.Run("Wrapped", func(t *testing.T) {
 			e := &errorTest{}
-			err := &doubleWrappedError{
-				wrapped: &errorTest{val: 100},
+			err := &internal.DoubleWrappedError{
+				Wrapped: &errorTest{val: 100},
 			}
 			if !errors.As(err, &e) {
 				t.Fatal("should not validate")
@@ -205,9 +207,9 @@ func TestPanics(t *testing.T) {
 		})
 		t.Run("WrappedAndCurrent", func(t *testing.T) {
 			e := &errorTest{}
-			err := &doubleWrappedError{
-				wrapped: &errorTest{val: 1000},
-				current: &errorTest{val: 9000},
+			err := &internal.DoubleWrappedError{
+				Wrapped: &errorTest{val: 1000},
+				Current: &errorTest{val: 9000},
 			}
 			if !errors.As(err, &e) {
 				t.Fatal("should not validate")

--- a/srv/service_test.go
+++ b/srv/service_test.go
@@ -316,7 +316,7 @@ func TestService(t *testing.T) {
 			hs2 := &http.Server{
 				Addr: "127.0.0.2:2340",
 			}
-			s2 := HTTP("test", time.Millisecond, hs2)
+			s2 := HTTP("test", 2*time.Millisecond, hs2)
 			if err := s2.Start(ctx); err != nil {
 				t.Error(err)
 			}


### PR DESCRIPTION
Mostly some new erc helpers, but also added test coverage to the internal package.

erc features include:
- errors.Is/errors.As helper for merging two errors
- Populating errors from an error channel and slices sing erc.Collector infrastructure